### PR TITLE
FIX: change Haversine distance mile conversion to use to_miles, otherwise throws error

### DIFF
--- a/gpx-stats.rb
+++ b/gpx-stats.rb
@@ -18,7 +18,7 @@ gpx.tracks.each do |t|
     # Skip calculations for the first point since there's no previous data
     if @prev_lat > 0
       # Get distance between current and previous point and convert to miles
-      d = Haversine.distance(p.lat, p.lon, @prev_lat, @prev_lon) * 0.6214
+      d = Haversine.distance(p.lat, p.lon, @prev_lat, @prev_lon).to_miles
       @distance += d
 
       if p.elevation > @prev_elevation


### PR DESCRIPTION
When I tried to run your script, I got this error:

` gpx-stats.rb:24:in block (2 levels) in <main>': undefined method *' for #<Haversine::Distance:0x00000000021a4878 @great_circle_distance=9.232945886449257e-07> (NoMethodError)`

That's because Haversine.distance() returns a Haversine::Distance object, not an actual number.
You can just use the to_miles method to return the miles. This made the script work for me.

Great work!